### PR TITLE
fix circup instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install guvx_i2c
+    circup install adafruit_guvx_i2c
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
Resolves the following issue for this library: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/407 for this library

Editted by: tekktrik (removing auto-linking issue)